### PR TITLE
Changed API call to api.darksky.net

### DIFF
--- a/authentic.widget/authentic.coffee
+++ b/authentic.widget/authentic.coffee
@@ -25,7 +25,7 @@ exclude: "minutely,hourly,alerts,flags"
 command: "echo {}"
 
 makeCommand: (apiKey, location) ->
-  "curl -sS 'https://api.forecast.io/forecast/#{apiKey}/#{location}?units=si&exclude=#{@exclude}'"
+  "curl -sS 'https://api.darksky.net/forecast/#{apiKey}/#{location}?units=si&exclude=#{@exclude}'"
 
 render: (o) -> """
 	<article id="content">


### PR DESCRIPTION
Changed API call to https://api.darksky.net/forecast/ since api.forecast.io doesn't exist anymore.
